### PR TITLE
remove AGGREGATION edge kind (issue #10)

### DIFF
--- a/core/include/EdgeKind.h
+++ b/core/include/EdgeKind.h
@@ -41,8 +41,7 @@ namespace sourcetrail
 		TEMPLATE_SPECIALIZATION = 1 << 7,
 		INCLUDE = 1 << 8,
 		IMPORT = 1 << 9,
-		AGGREGATION = 1 << 10,
-		MACRO_USAGE = 1 << 11,
+		MACRO_USAGE = 1 << 11, // needs new db version if decremented
 		ANNOTATION_USAGE = 1 << 12
 	};
 

--- a/core/src/EdgeKind.cpp
+++ b/core/src/EdgeKind.cpp
@@ -38,7 +38,6 @@ namespace sourcetrail
 			EdgeKind::TEMPLATE_SPECIALIZATION,
 			EdgeKind::INCLUDE,
 			EdgeKind::IMPORT,
-			EdgeKind::AGGREGATION,
 			EdgeKind::MACRO_USAGE
 		};
 


### PR DESCRIPTION
it can be removed because it is never stored to or read from the database