### PR TITLE
Enable Perl bindings on AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,12 +10,14 @@ environment:
           DEPLOY_CORE: 1
           DEPLOY_PYTHON_BINDINGS: 1
           DEPLOY_JAVA_BINDINGS: 1
+          DEPLOY_PERL_BINDINGS: 1
         - MBITS: 64
           PYTHON_VERSION: 37
           MSVC_VERSION: 15
           DEPLOY_CORE: 1
           DEPLOY_PYTHON_BINDINGS: 1
           DEPLOY_JAVA_BINDINGS: 1
+          DEPLOY_PERL_BINDINGS: 1
         
         - MBITS: 32
           PYTHON_VERSION: 37
@@ -43,13 +45,31 @@ install:
         # Install SWIG by Choco
         choco install -y --no-progress swig --version 4.0.1
         choco install -y --no-progress openjdk
-
+        # Install Strawberry Perl and put before any other Perls in %PATH%
+        if ($env:MBITS -eq "32") {
+            choco install -y --no-progress --forcex86 strawberryperl
+        } elseif ($env:MBITS -eq "64") {
+            choco install -y --no-progress strawberryperl
+        } else {
+            echo "No architecture set. Build will be canceled."
+        }
+        $Env:PATH="C:\strawberry\perl\bin;C:\strawberry\perl\site\bin;C:\strawberry\c\bin;$Env:PATH"
+        $Env:PERL_VERSION=$(perl -e 'print $^V')
 
 before_build:
     - mkdir build
     - cd build
     - cmake -G "%CMAKE_GENERATOR%" ../ -DBUILD_BINDINGS_PYTHON=%DEPLOY_PYTHON_BINDINGS% -DPYTHON_LIBRARY="%PYTHON_PATH%/libs/python%PYTHON_VERSION%.lib" -DBUILD_BINDINGS_JAVA=%DEPLOY_JAVA_BINDINGS%
     - cd ../
+    - ps: |
+        if ($Env:DEPLOY_PERL_BINDINGS -eq "1") {
+            mkdir build-perl
+            cd build-perl
+            # Need to use Unix Makefiles because Strawberry Perl is a MinGW environment
+            cmake -G "Unix Makefiles" ../ -DBUILD_BINDINGS_PERL=$Env:DEPLOY_PERL_BINDINGS
+            if ($LastExitCode -ne 0) { throw "Perl bindings: cmake failed with exit code $LastExitCode" }
+            cd ../
+        }
     - ps: $env:CORE_VERSION = Get-Content -Path ./version.txt
     - ps: $env:UNDERSCORED_CORE_VERSION = $env:CORE_VERSION.Replace(".", "_")
     - ps: echo "Core version is $env:CORE_VERSION"
@@ -63,15 +83,24 @@ build_script:
     - cd build
     - msbuild /p:configuration=Release /v:m ALL_BUILD.vcxproj
     - cd ../
+    - ps: |
+        if ($Env:DEPLOY_PERL_BINDINGS -eq "1") {
+            cd build-perl
+            gmake
+            if ($LastExitCode -ne 0) { throw "Perl bindings: gmake failed with exit code $LastExitCode" }
+            cd ../
+        }
 
 
 after_build:
     - ps: $env:CORE_PACKAGE_NAME = 'sourcetraildb_core_' + $env:UNDERSCORED_CORE_VERSION + '-windows-' + $env:MBITS + 'bit-msvc' + $env:MSVC_VERSION
     - ps: $env:PYTHON_PACKAGE_NAME = 'sourcetrailbd_python' + $env:PYTHON_VERSION + '_' + $env:UNDERSCORED_CORE_VERSION + '-windows-' + $env:MBITS + 'bit'
     - ps: $env:JAVA_PACKAGE_NAME = 'sourcetrailbd_java_' + $env:UNDERSCORED_CORE_VERSION + '-windows-' + $env:MBITS + 'bit'
+    - ps: $env:PERL_PACKAGE_NAME = 'sourcetrailbd_strawberry-perl-' + $env:PERL_VERSION + '_' + $env:UNDERSCORED_CORE_VERSION + '-windows-' + $env:MBITS + 'bit'
     - ps: echo $env:CORE_PACKAGE_NAME
     - ps: echo $env:PYTHON_PACKAGE_NAME
     - ps: echo $env:JAVA_PACKAGE_NAME
+    - ps: echo $env:PERL_PACKAGE_NAME
     
     - ps: $env:ARTIFACTS_TO_DEPLOY = ""
     
@@ -133,6 +162,24 @@ after_build:
             $env:ARTIFACTS_TO_DEPLOY = $env:ARTIFACTS_TO_DEPLOY + "," + $env:JAVA_PACKAGE_NAME
         }
     - ps: |
+        mkdir artifacts_bindings_perl
+        if ($env:DEPLOY_PERL_BINDINGS -eq "1") {
+            cd artifacts_bindings_perl
+            mkdir $env:PERL_PACKAGE_NAME
+            cd $env:PERL_PACKAGE_NAME
+            mkdir license
+            cd ../..
+
+            copy build-perl/bindings_perl/sourcetraildb.dll artifacts_bindings_perl/$env:PERL_PACKAGE_NAME/
+            copy build-perl/bindings_perl/sourcetraildb.pm artifacts_bindings_perl/$env:PERL_PACKAGE_NAME/
+            copy LICENSE.txt artifacts_bindings_perl/$env:PERL_PACKAGE_NAME/license/license_sourcetraildb.txt
+            copy external/catch/license_catch.txt artifacts_bindings_perl/$env:PERL_PACKAGE_NAME/license/
+            copy external/cpp_sqlite/license_cpp_sqlite.txt artifacts_bindings_perl/$env:PERL_PACKAGE_NAME/license/
+            copy external/json/license_json.txt artifacts_bindings_perl/$env:PERL_PACKAGE_NAME/license/
+
+            $env:ARTIFACTS_TO_DEPLOY = $env:ARTIFACTS_TO_DEPLOY + "," + $env:PERL_PACKAGE_NAME
+        }
+    - ps: |
         $env:ARTIFACTS_TO_DEPLOY = $env:ARTIFACTS_TO_DEPLOY.substring(1)
         echo $env:ARTIFACTS_TO_DEPLOY
 
@@ -150,6 +197,9 @@ artifacts:
       type: Zip
     - path: artifacts_bindings_java
       name: $(JAVA_PACKAGE_NAME)
+      type: Zip
+    - path: artifacts_bindings_perl
+      name: $(PERL_PACKAGE_NAME)
       type: Zip
 
 


### PR DESCRIPTION
Uses Strawberry Perl which means it can not use MSVC as Strawberry Perl is configured for MinGW.

As discussed in <https://github.com/CoatiSoftware/SourcetrailDB/pull/23#issuecomment-698776600>.

Depends on <https://github.com/CoatiSoftware/SourcetrailDB/pull/38>.