### PR TITLE
Add CMake rules to generate C# bindings

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -7,5 +7,6 @@ Code Contributors
 =================
 
 Andrew Pam (@xanni) <andrew@sericyb.com.au>
+Jørgen Lund (@strangebroadcasts) <jlund@strangebroadcasts.com>
 
 Note: (@user) means a github user name.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,7 @@ cmake_minimum_required (VERSION 2.6)
 set(BUILD_BINDINGS_PERL OFF CACHE BOOL "Build the SourcetrailDB Perl bindings.")
 set(BUILD_BINDINGS_PYTHON OFF CACHE BOOL "Build the SourcetrailDB Python bindings.")
 set(BUILD_BINDINGS_JAVA OFF CACHE BOOL "Build the SourcetrailDB Java bindings.")
+set(BUILD_BINDINGS_CSHARP OFF CACHE BOOL "Build the SourcetrailDB C# bindings.")
 set(BUILD_EXAMPLES ON CACHE BOOL "Build the examples.")
 
 set(PROJECT_NAME "SourcetrailDB")
@@ -83,6 +84,16 @@ else()
 	message(STATUS "Building the SourcetrailDB Java bindings will be skipped. You can enable building this target by setting 'BUILD_BINDINGS_JAVA' to 'ON'.")
 endif()
 
+# --- C# Binding ---
+if (BUILD_BINDINGS_CSHARP)
+	message(STATUS "The SourcetrailDB C# bindings will be built.")
+
+	set(CSHARP_BINDING_TARGET_NAME "bindings_csharp")
+	set(CSHARP_BINDING_OUTPUT_DIR "")
+	add_subdirectory("${CMAKE_SOURCE_DIR}/bindings_csharp" "${CMAKE_BINARY_DIR}/bindings_csharp")
+else()
+	message(STATUS "Building the SourcetrailDB C# bindings will be skipped. You can enable building this target by setting 'BUILD_BINDINGS_CSHARP' to 'ON'.")
+endif()
 
 # --- Examples ---
 

--- a/README.md
+++ b/README.md
@@ -38,9 +38,9 @@ Even though the core implementation is written in C++, this does not require you
 * Perl (via [SWIG](http://www.swig.org/))
 * Python (via [SWIG](http://www.swig.org/))
 * Java (via [SWIG](http://www.swig.org/))
+* C# (via [SWIG](http://www.swig.org/))
 
 If the language of your choice is not covered by this list, feel free to [open an issue](https://github.com/CoatiSoftware/SourcetrailDB/issues) or provide a pull request.
-
 
 ## Versioning
 
@@ -148,6 +148,20 @@ $ make
 ```
 
 Swig is configured to generate the Java binding code as a pre-build event, so you don't need to bother with updating manually.
+
+### C# Bindings
+
+Requirements:
+* [SWIG 3.0.12](http://www.swig.org/) is used to automatically generate C# binding code. Make sure that SWIG is added to your path environment variable.
+
+If you want to build the C# bindings run:
+```
+$ cd path/to/SourcetrailDB
+$ mkdir build
+$ cd build
+$ cmake -DBUILD_BINDINGS_CSHARP=ON ..
+$ make
+```
 
 ### Examples
 

--- a/bindings_csharp/CMakeLists.txt
+++ b/bindings_csharp/CMakeLists.txt
@@ -1,0 +1,40 @@
+cmake_minimum_required (VERSION 2.6)
+
+# --- Setup Paths ---
+
+set(RESOURCES_SWIG_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../resources_swig")
+set(GENERATED_SRC_DIR "${CMAKE_CURRENT_BINARY_DIR}/src")
+set(CSHARP_BINDING_OUTPUT_DIR ${CMAKE_CURRENT_BINARY_DIR} PARENT_SCOPE)
+
+set(SWIG_INTERFACE_FILE "${RESOURCES_SWIG_DIR}/interface/sourcetraildb.i")
+set(CSHARP_BINDINGS_NAMESPACE "CoatiSoftware.SourcetrailDB")
+
+# --- Find Swig ---
+
+find_package(SWIG REQUIRED)
+include(${SWIG_USE_FILE})
+
+# --- Configure Target ---
+
+set_source_files_properties(${SWIG_INTERFACE_FILE} PROPERTIES CPLUSPLUS ON)
+set_property(SOURCE ${SWIG_INTERFACE_FILE} PROPERTY COMPILE_OPTIONS -namespace ${CSHARP_BINDINGS_NAMESPACE})
+
+include_directories(
+	"${RESOURCES_SWIG_DIR}/include"
+	"${CORE_SOURCE_DIR}/include"
+)
+
+swig_add_library(
+	${CSHARP_BINDING_TARGET_NAME}
+	TYPE SHARED
+	LANGUAGE csharp
+	OUTPUT_DIR ${CSHARP_BINDING_OUTPUT_DIR}
+	OUTFILE_DIR ${GENERATED_SRC_DIR}
+	SOURCES ${SWIG_INTERFACE_FILE} ${RESOURCES_SWIG_DIR}/src/sourcetraildb.cpp
+)
+
+set_target_properties(${CSHARP_BINDING_TARGET_NAME}
+                      PROPERTIES OUTPUT_NAME SourcetrailDB
+	SWIG_FLAGS ${CSHARP_BINDINGS_NAMESPACE})
+
+swig_link_libraries(${CSHARP_BINDING_TARGET_NAME} ${CSHARP_LIBRARIES} ${LIB_CORE_TARGET_NAME})

--- a/bindings_csharp/CMakeLists.txt
+++ b/bindings_csharp/CMakeLists.txt
@@ -8,6 +8,7 @@ set(CSHARP_BINDING_OUTPUT_DIR ${CMAKE_CURRENT_BINARY_DIR} PARENT_SCOPE)
 
 set(SWIG_INTERFACE_FILE "${RESOURCES_SWIG_DIR}/interface/sourcetraildb.i")
 set(CSHARP_BINDINGS_NAMESPACE "CoatiSoftware.SourcetrailDB")
+set(CSHARP_BINDING_TARGET_OUTPUT_NAME "SourcetrailDB")
 
 # --- Find Swig ---
 
@@ -17,7 +18,7 @@ include(${SWIG_USE_FILE})
 # --- Configure Target ---
 
 set_source_files_properties(${SWIG_INTERFACE_FILE} PROPERTIES CPLUSPLUS ON)
-set_property(SOURCE ${SWIG_INTERFACE_FILE} PROPERTY COMPILE_OPTIONS -namespace ${CSHARP_BINDINGS_NAMESPACE})
+set_property(SOURCE ${SWIG_INTERFACE_FILE} PROPERTY COMPILE_OPTIONS -namespace ${CSHARP_BINDINGS_NAMESPACE} -dllimport ${CSHARP_BINDING_TARGET_OUTPUT_NAME})
 
 include_directories(
 	"${RESOURCES_SWIG_DIR}/include"
@@ -34,7 +35,7 @@ swig_add_library(
 )
 
 set_target_properties(${CSHARP_BINDING_TARGET_NAME}
-                      PROPERTIES OUTPUT_NAME SourcetrailDB
+                      PROPERTIES OUTPUT_NAME ${CSHARP_BINDING_TARGET_OUTPUT_NAME}
 	SWIG_FLAGS ${CSHARP_BINDINGS_NAMESPACE})
 
 swig_link_libraries(${CSHARP_BINDING_TARGET_NAME} ${CSHARP_LIBRARIES} ${LIB_CORE_TARGET_NAME})

--- a/bindings_csharp/CMakeLists.txt
+++ b/bindings_csharp/CMakeLists.txt
@@ -39,3 +39,5 @@ set_target_properties(${CSHARP_BINDING_TARGET_NAME}
 	SWIG_FLAGS ${CSHARP_BINDINGS_NAMESPACE})
 
 swig_link_libraries(${CSHARP_BINDING_TARGET_NAME} ${CSHARP_LIBRARIES} ${LIB_CORE_TARGET_NAME})
+
+configure_file("CoatiSoftware.SourcetrailDB.csproj" "CoatiSoftware.SourcetrailDB.csproj" COPYONLY)

--- a/bindings_csharp/CoatiSoftware.SourcetrailDB.csproj
+++ b/bindings_csharp/CoatiSoftware.SourcetrailDB.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(OS)' == 'Windows_NT'">
+    <Content Include="$(ProjectDir)/SourcetrailDB.dll">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        <Link>SourcetrailDB.dll</Link>
+    </Content>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Linux)))'">
+    <Content Include="$(ProjectDir)/SourcetrailDB.so">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        <Link>SourcetrailDB.so</Link>
+    </Content>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::OSX)))'">
+    <Content Include="$(ProjectDir)/SourcetrailDB.dylib">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        <Link>SourcetrailDB.dylib</Link>
+    </Content>
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Set up the CMake / SWIG rules to generate C# bindings in the `bindings_csharp` directory of the build output. I'm currently using these bindings to set up a proof-of-concept for a Roslyn-based indexer for C# projects (using SemanticModel, as suggested in [this excellent comment](https://github.com/CoatiSoftware/SourcetrailDB/issues/17#issuecomment-561472838) on the .NET language request issue).

These bindings are fairly barebones at the moment - the methods are exposed directly as static methods on a single `sourcetraildb` (lowercase) class under the namespace `CoatiSoftware.SourcetrailDB`. If anyone knows how to coax SWIG into generating PascalCase class and method names, I would love to hear about it!

Another issue is how projects should reference the bindings: currently, you need to manually set up a .csproj for the bindings (or include them directly in the project), and ensure that SourcetrailDB.dll is in the search path, which works, but is somewhat awkward. 

Ideally, you'd create a [NuGet package](https://docs.microsoft.com/en-us/nuget/what-is-nuget) containing the bindings and the library, which would let applications and libraries include the bindings trivially. However, it would have to embed the SourcetrailDB core .dll, and someone at Coati Software would need to maintain it, building and uploading new packages to nuget.org when the SourcetrailDB core is updated.

If that's not an option, another solution would be to have the build process autogenerate a .csproj file for the bindings, with targets to copy SourcetrailDB.dll into the build output directory - generating the C# bindings would then create a project you can drop into an existing solution, which should work well enough.